### PR TITLE
Preserve value types

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -5,6 +5,7 @@ const async = require('async');
 const fsBackend = require('./backends/fs');
 const mongoBackend = require('./backends/mongo');
 const resolveSelections = require('./utils/resolveSelections');
+const types = require('./utils/types');
 
 /**
  * Actual logic to export multiple collections
@@ -52,7 +53,7 @@ function exportCollections(opts, callback) {
         return fsBackend.ensureDir(dataDir, () => {
           fsBackend.writeFile(
             `${dataDir}/${collection}.json`,
-            docs,
+            _.map(docs, types.wrap),
             { spaces: 2 },
             (writeErr) => {
               if (writeErr) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -5,7 +5,7 @@ const async = require('async');
 const fsBackend = require('./backends/fs');
 const mongoBackend = require('./backends/mongo');
 const resolveSelections = require('./utils/resolveSelections');
-const types = require('./utils/types');
+const typecast = require('./utils/typecast');
 
 /**
  * Actual logic to export multiple collections
@@ -53,7 +53,7 @@ function exportCollections(opts, callback) {
         return fsBackend.ensureDir(dataDir, () => {
           fsBackend.writeFile(
             `${dataDir}/${collection}.json`,
-            _.map(docs, types.wrap),
+            _.map(docs, typecast.wrap),
             { spaces: 2 },
             (writeErr) => {
               if (writeErr) {

--- a/lib/import.js
+++ b/lib/import.js
@@ -5,7 +5,7 @@ const async = require('async');
 const fsBackend = require('./backends/fs');
 const mongoBackend = require('./backends/mongo');
 const resolveSelections = require('./utils/resolveSelections');
-const types = require('./utils/types');
+const typecast = require('./utils/typecast');
 
 /**
  * Actual logic to import multiple collections
@@ -44,7 +44,9 @@ function importCollections(opts, callback) {
       console.log(`┌ Importing "${collection}" (${readData.length} documents)`);
 
       const col = dbConn.collection(collection);
-      return col.insertMany(_.map(readData, types.unwrap), (writeErr) => {
+      const dataToInsert = _.map(readData, typecast.unwrap);
+
+      return col.insertMany(dataToInsert, (writeErr) => {
         console.log(`└ Successfully imported "${collection}" collection.`);
         return cb(writeErr);
       });

--- a/lib/import.js
+++ b/lib/import.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+const _ = require('lodash');
 const async = require('async');
 
 const fsBackend = require('./backends/fs');
 const mongoBackend = require('./backends/mongo');
 const resolveSelections = require('./utils/resolveSelections');
+const types = require('./utils/types');
 
 /**
  * Actual logic to import multiple collections
@@ -42,7 +44,7 @@ function importCollections(opts, callback) {
       console.log(`┌ Importing "${collection}" (${readData.length} documents)`);
 
       const col = dbConn.collection(collection);
-      return col.insertMany(readData, (writeErr) => {
+      return col.insertMany(_.map(readData, types.unwrap), (writeErr) => {
         console.log(`└ Successfully imported "${collection}" collection.`);
         return cb(writeErr);
       });

--- a/lib/utils/typecast.js
+++ b/lib/utils/typecast.js
@@ -4,30 +4,39 @@ const mongodb = require('mongodb');
 const ObjectID = mongodb.ObjectID;
 
 /**
- * Wraps a single value into an object
- * @param {*} val Any value taken directly from DB
- * @returns {object} Wrapped object with properties: type, value
+ * Detects type of a value and identifies ObjectIDs, arrays and nulls
+ * as the correct type rather than just object
  */
-function wrapSingleValue(val) {
-  let detectedType = typeof val;
-
+function detectType(val) {
   if (typeof val === 'object') {
     if (ObjectID.isValid(val)) {
-      detectedType = 'ObjectID';
+      return 'ObjectID';
     }
 
     if (Array.isArray(val)) {
-      detectedType = 'array';
+      return 'array';
     }
 
-    if (!val) {
-      detectedType = 'null';
+    if (val === null) {
+      return 'null';
     }
   }
 
+  const detectedType = typeof val;
+  return detectedType;
+}
+
+/**
+ * Wraps a single value into an object
+ * @param {*} val Any value taken directly from DB
+ * @return {object} Wrapped object with properties: type, value
+ */
+function wrapSingleValue(value) {
+  const detectedType = detectType(value);
+
   const wrapped = {
     type: detectedType,
-    value: val
+    value: value
   };
 
   return wrapped;
@@ -35,14 +44,14 @@ function wrapSingleValue(val) {
 
 /**
  * Unwraps/casts a single value from a previously wrapped object
- * Casts MongoIDs to the correct type
+ * Casts Mongo ObjectIDs to the correct type
  *
  * @param {object} wrapper Value wrapped in an object with type and value
- * @returns {*} Unwrapped/casted value matching what was originally taken from DB
+ * @return {*} Unwrapped/casted value matching what was originally taken from DB
  */
 function unwrapSingleValue(wrapper) {
   // console.log('unwrapSingleValue', wrapper);
-  let unwrapped = wrapper.val;
+  let unwrapped = wrapper.value;
 
   if (wrapper.type === 'ObjectID') {
     unwrapped = ObjectID(unwrapped);
@@ -51,6 +60,12 @@ function unwrapSingleValue(wrapper) {
   return unwrapped;
 }
 
+/**
+ * Runs the wrapping of values over an entire payload/document
+ *
+ * @param {object} payload Entire document from database to interate over
+ * @return {object} Document mapped to include types and values for every property
+ */
 function wrap(payload) {
   const rtn = {};
   _.each(payload, (v, k) => {

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const mongodb = require('mongodb');
+
+const ObjectID = mongodb.ObjectID;
+
+function wrapSingleValue(val) {
+  let detectedType = typeof val;
+
+  if (ObjectID.isValid(val)) {
+    detectedType = 'ObjectID';
+  }
+
+  if (Array.isArray(val)) {
+    detectedType = 'array';
+  }
+
+  const wrapped = {
+    type: detectedType,
+    value: val
+  };
+
+  return wrapped;
+}
+
+function unwrapSingleValue(wrapper) {
+  console.log('unwrapSingleValue', wrapper);
+  let unwrapped = wrapper.val;
+
+  if (wrapper.type === 'ObjectID') {
+    unwrapped = ObjectID(unwrapped);
+  }
+
+  return unwrapped;
+}
+
+function wrap(payload) {
+  const rtn = {};
+  _.each(payload, (v, k) => {
+    if (typeof v === 'object' && !Array.isArray(v) && !ObjectID.isValid(v)) {
+      rtn[k] = wrap(v);
+    }
+
+    rtn[k] = wrapSingleValue(v);
+  });
+  return rtn;
+}
+
+function unwrap(payload) {
+  const rtn = {};
+  _.each(payload, (v, k) => {
+    if (v.type === 'object') {
+      rtn[k] = unwrap(v);
+    }
+
+    rtn[k] = unwrapSingleValue(v);
+  });
+  return rtn;
+}
+
+module.exports = {
+  wrap,
+  unwrap
+};

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -3,15 +3,26 @@ const mongodb = require('mongodb');
 
 const ObjectID = mongodb.ObjectID;
 
+/**
+ * Wraps a single value into an object
+ * @param {*} val Any value taken directly from DB
+ * @returns {object} Wrapped object with properties: type, value
+ */
 function wrapSingleValue(val) {
   let detectedType = typeof val;
 
-  if (ObjectID.isValid(val)) {
-    detectedType = 'ObjectID';
-  }
+  if (typeof val === 'object') {
+    if (ObjectID.isValid(val)) {
+      detectedType = 'ObjectID';
+    }
 
-  if (Array.isArray(val)) {
-    detectedType = 'array';
+    if (Array.isArray(val)) {
+      detectedType = 'array';
+    }
+
+    if (!val) {
+      detectedType = 'null';
+    }
   }
 
   const wrapped = {
@@ -22,8 +33,15 @@ function wrapSingleValue(val) {
   return wrapped;
 }
 
+/**
+ * Unwraps/casts a single value from a previously wrapped object
+ * Casts MongoIDs to the correct type
+ *
+ * @param {object} wrapper Value wrapped in an object with type and value
+ * @returns {*} Unwrapped/casted value matching what was originally taken from DB
+ */
 function unwrapSingleValue(wrapper) {
-  console.log('unwrapSingleValue', wrapper);
+  // console.log('unwrapSingleValue', wrapper);
   let unwrapped = wrapper.val;
 
   if (wrapper.type === 'ObjectID') {


### PR DESCRIPTION
Addresses #6

Every document exported and imported will go through typecasting logic (`./lib/utils/typecast.js`).

Exporting from DBs will serialise the data (wrap) - type will be stored with all additional types supported (currently only ObjectID). Format: `{type: 'ObjectID', value: '5a318871e9211a7ff43a4ceb'}`

Importing from files will deserialise the data in the process (unwrap) - the value will be casted from what's stored in JSON to what it originated as.