### PR TITLE
Move logging to CLI layer, pass data correctly in callbacks

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,28 +2,43 @@ const exportRoutine = require('./lib/export');
 const importRoutine = require('./lib/import');
 const countRoutine = require('./lib/count');
 
-const exportOpts = {
-  host: 'localhost',
-  db: 'example-data-prod',
-  dataDir: 'data/20180622-example-data-prod',
-  exclude: ['files', 'sessions']
-};
-
 const importOpts = {
   host: 'localhost',
-  db: '20180622-example-data-prod',
-  dataDir: 'data/20180622-example-data-prod',
-  exclude: ['config']
+  db: 'dbclone-dev',
+  dataDir: 'dbclone-dev-20180622',
+  exclude: ['config', 'private']
+};
+
+const exportOpts = {
+  host: 'localhost',
+  db: 'dbclone-dev',
+  dataDir: 'dbclone-dev-20181024',
+  exclude: ['files', 'sessions']
 };
 
 const countOpts = {
   host: 'localhost',
-  db: '20180622-example-data-prod',
-  collections: ['example', 'users', 'prod']
+  db: 'dbclone-dev',
+  collections: ['pages', 'configs', 'prod']
 };
 
-exportRoutine(exportOpts, () => {
-  importRoutine(importOpts, () => {});
-});
+importRoutine(importOpts, (importErr, importData) => {
+  if (importErr) {
+    console.error('Import Error:', importErr);
+  }
+  console.log('Import Data:', importData);
 
-countRoutine(countOpts, () => { });
+  exportRoutine(exportOpts, (exportErr, exportData) => {
+    if (exportErr) {
+      console.error('Export Error:', exportErr);
+    }
+    console.log('Export Data:', exportData);
+
+    countRoutine(countOpts, (countErr, countData) => {
+      if (countErr) {
+        console.error('Count Error:', countErr);
+      }
+      console.log('Count Data:', countData);
+    });
+  });
+});

--- a/lib/backends/fs.js
+++ b/lib/backends/fs.js
@@ -11,7 +11,7 @@ function resolvePath(inputPath) {
 }
 
 function scanDirSync(dataDir) {
-  console.log(`(Scanning ${dataDir}...)\n`);
+  // console.log(`(Scanning ${dataDir}...)\n`);
 
   return map(
     glob.sync(`${dataDir}/*`),

--- a/lib/backends/mongo.js
+++ b/lib/backends/mongo.js
@@ -25,12 +25,10 @@ function dbConnectionOpen(host, db, cb) {
   return MongoClient.connect(url, { useNewUrlParser: true }, (err, client) => {
     if (err || !client) {
       const errorMsg = `Couldn't connect to Mongo at ${url}`;
-      console.error(errorMsg, err);
+      // console.error(errorMsg, err);
       return cb(err || errorMsg);
     }
 
-    console.log(`Host:        ${host}`);
-    console.log(`Selected DB: ${db}`);
     MongoClientInstance = client;
     MongoDBInstance = client.db(db);
     return cb(null, MongoDBInstance);
@@ -49,7 +47,7 @@ function dbConnectionClose() {
 
 
 function listCollections(connDb, callback) {
-  console.log('(Scanning Mongo...)\n');
+  // console.log('(Scanning Mongo...)\n');
 
   return connDb.listCollections().toArray((listErr, listData) => {
     const allCollections = _.map(listData, 'name');

--- a/lib/cli/generateHelpText.js
+++ b/lib/cli/generateHelpText.js
@@ -18,7 +18,7 @@ It will guide you through the relevant operation.
 Alternatively you can specify exact operation you want
 to execute by adding it to the command with required parameters, for example:
 
-$ dbclone export --host localhost --db my-app
+$ dbclone export --db my-app --dataDir my-app-export-20181024
 
 This will execute export operation to the default directory (data) using all
 collections found in the target database.
@@ -27,8 +27,8 @@ These modes all require MongoDB host (--host) and a database name (--db).
 
 More parameters are supported. Examples:
 
-$ dbclone export --host localhost --db my-app --dataDir test
-$ dbclone export --host localhost --db my-app --exclude private --hide-secrets
+$ dbclone import --db my-app --dataDir test
+$ dbclone export --host mongodb://user:password@mongo.myapp.com --db my-app --exclude private
 
 You can provide a full Mongo URI to --host option which will allow you
 to provide more info like authentication or replica sets.

--- a/lib/cli/parseInput.js
+++ b/lib/cli/parseInput.js
@@ -1,8 +1,17 @@
+const _ = require('lodash');
 const inquirer = require('inquirer');
 const lib = require('..');
 const generateHelpText = require('./generateHelpText');
 
+/**
+ * @param {string} opts.message Question for the user
+ * @param {function} opts.actionFn Callback function
+ */
 function confirmSelection(opts) {
+  if (opts.force) {
+    return opts.actionFn({ confirm: 'yes' });
+  }
+
   const questions = [{
     type: 'list',
     name: 'confirm',
@@ -11,70 +20,142 @@ function confirmSelection(opts) {
     filter: val => val.toLowerCase()
   }];
 
-  inquirer.prompt(questions).then(answers => opts.actionFn(answers));
+  return inquirer.prompt(questions).then(answers => opts.actionFn(answers));
 }
 
+function displayDetailedSummary(data) {
+  return _.each(data, (col) => {
+    if (col && col.collection) {
+      const outputLine = `${_.padEnd(col.collection, 18, '.')}${_.padStart(col.documents, 8, '.')} documents`;
+      console.log(outputLine);
+    }
+  });
+}
+
+function exportAction(opts) {
+  console.log(`Starting export of "${opts.db}" (${opts.host}) to "${opts.dataDir}"\n`);
+
+  return lib.export(opts, (err, data) => {
+    if (err) {
+      console.error('Export error:', err);
+    }
+
+    console.log(`Successfully exported ${data.length} collections from "${opts.db}" (${opts.host}) to "${opts.dataDir}"\n`);
+
+    return displayDetailedSummary(data);
+  });
+}
+
+function importAction(opts) {
+  console.log(`Starting import of "${opts.dataDir}" to "${opts.db}" (${opts.host})\n`);
+
+  return lib.import(opts, (err, data) => {
+    if (err) {
+      console.error('Import error:', err);
+    }
+
+    console.log(`Successfully imported ${data.length} collections to "${opts.db}" (${opts.host})\n`);
+
+    return displayDetailedSummary(data);
+  });
+}
+
+function countAction(opts) {
+  return lib.count(opts, (err, data) => {
+    console.log(`Counting documents in "${opts.db}" (${opts.host})...\n`);
+
+    if (err) {
+      return console.error('Count error:', err);
+    }
+
+    return displayDetailedSummary(data);
+  });
+}
+
+function dropAction(opts) {
+  const message = `Are you sure you want to drop database "${opts.db}" from host "${opts.host}"?`;
+
+  const actionFn = (confirmResult) => {
+    if (confirmResult.confirm !== 'yes') {
+      return console.log('Database drop aborted.');
+    }
+
+    console.log(`Dropping database "${opts.db}" on "${opts.host}"...\n`);
+
+    return lib.drop(opts, (err, data) => {
+      if (err) {
+        console.error('Drop error:', err);
+      }
+
+      console.log(`Database "${opts.db}" (${opts.host}) dropped successfully (${data}).`);
+    });
+  };
+
+  return confirmSelection({ message, actionFn, force: opts.force });
+}
+
+function helpAction() {
+  const helpTextString = generateHelpText();
+  return console.log(helpTextString);
+}
+
+
+const Actions = {
+  export: exportAction,
+  import: importAction,
+  count: countAction,
+  drop: dropAction,
+  help: helpAction,
+};
+
+/**
+ * @param {object} result Data collected from the user either through
+ * CLI arguments or interactive prompt
+ */
 function parseInput(result) {
-  if (!result || !result.mode) {
-    return console.log(`Couldn't pick a mode from provided input: ${JSON.stringify(result, null, 2)}`);
+  if (!result || !result.mode || !Actions[result.mode]) {
+    console.log(`Couldn't locate selected mode: "${result ? result.mode : result}"`);
+    return process.exit(1);
   }
 
-  /* Info modes */
   if (result.mode === 'help') {
-    const helpTextString = generateHelpText();
-    return console.log(helpTextString);
+    return Actions.help();
   }
 
-  /* Action modes */
   const optsObj = result.opts || result || {};
 
-  if (!(optsObj.host || result.host) && !(optsObj.db || result.db)) {
-    return console.log('Missing database info. Please specify --host and --db');
+  // default host to localhost
+  optsObj.host = optsObj.host || 'localhost';
+
+  if (!(optsObj.db || result.db)) {
+    return console.log('Missing database info. Please specify --db parameter.');
   }
 
+  if (optsObj.verbose) {
+    console.log('----------------------------------');
+    console.log(`Host:         ${optsObj.host}`);
+    console.log(`Selected DB:  ${optsObj.db}`);
+    console.log('----------------------------------');
+  }
 
   if (result.mode === 'import') {
-    return lib.import(optsObj, () => {
-      console.log('Import finished.');
-    });
+    return Actions.import(optsObj);
   }
 
   if (result.mode === 'export') {
-    return lib.export(optsObj, () => {
-      console.log('Export finished.');
-    });
+    return Actions.export(optsObj);
   }
 
   if (result.mode === 'count') {
-    return lib.count(optsObj, () => {
-      console.log('Count finished.');
-    });
+    return Actions.count(optsObj);
   }
 
+  // Drop database
   if (result.mode === 'drop') {
-    if (optsObj.force) {
-      return lib.drop(optsObj, () => {
-        console.log('Drop database finished.');
-      });
-    }
-
-    const message = `Are you sure you want to drop database "${optsObj.db}" from host "${optsObj.host}"?`;
-
-    const actionFn = (confirmResult) => {
-      if (confirmResult.confirm !== 'yes') {
-        return console.log('Aborted.');
-      }
-
-      return lib.drop(optsObj, () => {
-        console.log('Drop database finished.');
-      });
-    };
-
-    return confirmSelection({ message, actionFn });
+    return Actions.drop(optsObj);
   }
 
-  console.log('Couldn\'t resolve mode');
-  return false;
+  throw new Error('Couldn\'t match provided mode');
 }
 
 module.exports = parseInput;

--- a/lib/count.js
+++ b/lib/count.js
@@ -16,7 +16,7 @@ function countDocuments(opts, callback) {
   const dbConn = opts.connection;
 
   if (!dbConn) {
-    return callback('MongoDBClient must be provided to countDocuments method.');
+    return callback('MongoDBClient must be provided to "countDocuments" method.');
   }
 
   function count(collection, cb) {
@@ -25,7 +25,7 @@ function countDocuments(opts, callback) {
     }
 
     if (!collection) {
-      return cb('> Missing collection name in call to count method');
+      return cb('Missing collection name in call to "count" method');
     }
 
     return mongoBackend.countDocuments(dbConn, collection, (err, value) => {
@@ -33,25 +33,17 @@ function countDocuments(opts, callback) {
         return cb(err);
       }
 
-      console.log('------------------');
-      console.log(`Collection: ${collection}`);
-      console.log(`Documents : ${value}`);
-
-      return cb(null, value);
+      return cb(null, { collection, documents: value });
     });
   }
 
-  return async.eachLimit(list, 1, count, (countErr, value) => {
+  return async.mapLimit(list, 1, count, (countErr, value) => {
     if (countErr) {
       return callback(countErr);
     }
 
-    console.log('------------------');
-    console.log('Finished count data in Mongo');
-    console.log(value);
-    console.log('------------------');
     mongoBackend.close(dbConn);
-    return callback();
+    return callback(null, value);
   });
 }
 

--- a/lib/drop.js
+++ b/lib/drop.js
@@ -34,11 +34,10 @@ function main(opts, callback) {
 
   return mongoBackend.open(opts.host, opts.db, (connErr, connDb) => {
     if (connErr) {
-      console.error('Couldn\'t connect to specified MongoDB', connErr);
-      return process.exit(2);
+      // console.error('Couldn\'t connect to specified MongoDB', connErr);
+      // return process.exit(2);
+      return callback(connErr);
     }
-
-    console.log(`Dropping database "${opts.db}"...`);
 
     const newOpts = {
       connection: connDb,

--- a/lib/export.js
+++ b/lib/export.js
@@ -46,7 +46,7 @@ function exportCollections(opts, callback) {
       if (countErr) {
         return cb(countErr);
       }
-      console.log(`┌ Exporting collection: "${collection}" (${countRes} documents)`);
+      // console.log(`┌ Exporting collection: "${collection}" (${countRes} documents)`);
 
       return query.toArray((err, docs) => {
         if (err) {
@@ -58,13 +58,13 @@ function exportCollections(opts, callback) {
             `${dataDir}/${collection}.json`,
             _.map(docs, typecast.wrap),
             { spaces: 2 },
-            (writeErr) => {
+            (writeErr, writeSuccess) => {
               if (writeErr) {
-                console.log(`└ ERR Problem exporting collection: "${collection}".`);
+                // console.log(`└ ERR Problem exporting collection: "${collection}".`);
                 return cb(writeErr);
               }
-              console.log(`└ Successfully exported collection: "${collection}".`);
-              return cb(writeErr);
+              // console.log(`└ Successfully exported collection: "${collection}".`);
+              return cb(null, { collection, documents: countRes });
             }
           );
         });
@@ -73,20 +73,20 @@ function exportCollections(opts, callback) {
   }
 
   // start exporting all resolved collections
-  return async.eachLimit(list, LIMIT, exportOne, (exportErr) => {
+  return async.mapLimit(list, LIMIT, exportOne, (exportErr, exportData) => {
     if (exportErr) {
-      console.log('------------------');
-      console.log('Errors during export from Mongo');
-      console.log('------------------');
-      console.error(exportErr);
+      // console.log('------------------');
+      // console.log('Errors during export from Mongo');
+      // console.log('------------------');
+      // console.error(exportErr);
       return callback(exportErr);
     }
 
-    console.log('------------------');
-    console.log('Finished exporting data from Mongo');
-    console.log('------------------');
+    // console.log('------------------');
+    // console.log('Finished exporting data from Mongo');
+    // console.log('------------------');
     mongoBackend.close(dbConn);
-    return callback();
+    return callback(null, exportData);
   });
 }
 
@@ -116,7 +116,7 @@ function main(opts, callback) {
   const collectionsToInclude = parsePotentialArray(opts.include);
   const collectionsToExclude = parsePotentialArray(opts.exclude);
 
-  console.log(`Exporting to ${dataDir}`);
+  // console.log(`Exporting to ${dataDir}`);
 
   mongoBackend.open(opts.host, opts.db, (connErr, connDb) => {
     if (connErr) {
@@ -124,9 +124,9 @@ function main(opts, callback) {
       return process.exit(2);
     }
 
-    console.log('------------------');
-    console.log('Starting export...');
-    console.log('------------------');
+    // console.log('------------------');
+    // console.log('Starting export...');
+    // console.log('------------------');
 
     return mongoBackend.listCollections(connDb, (err, allCollections) => {
       const resolved = resolveSelections(

--- a/lib/import.js
+++ b/lib/import.js
@@ -44,7 +44,9 @@ function importCollections(opts, callback) {
         return cb(readErr);
       }
 
-      console.log(`┌ Importing "${collection}" (${readData.length} documents)`);
+      if (opts.verbose) {
+        console.log(`┌ Importing "${collection}" (${readData.length} documents)`);
+      }
 
       const col = dbConn.collection(collection);
       const dataToInsert = _.map(readData, typecast.unwrap);
@@ -55,31 +57,34 @@ function importCollections(opts, callback) {
 
       return col.insertMany(dataToInsert, (writeErr) => {
         if (writeErr) {
-          console.log(`└ Error while importing "${collection}" collection.`);
-          console.error(`\x1b[31m  ${writeErr.errmsg}\x1b[0m`);
+          if (opts.verbose) {
+            console.log(`└ Error while importing "${collection}" collection.`);
+            console.error(`\x1b[31m  ${writeErr.errmsg}\x1b[0m`);
+          }
           // if (writeErr.code === 11000) {
           //   console.log('You can ignore index restoration with --noIndex');
           //   console.log('You can try dropping the database and trying again.');
           // }
           return cb(writeErr);
         }
-        console.log(`└ Successfully imported "${collection}" collection.`);
-        return cb();
+
+        if (opts.verbose) {
+          console.log(`└ Successfully imported "${collection}" collection.`);
+        }
+
+        return cb(null, { collection, documents: readData.length });
       });
     });
   }
 
   // process each file and insert in Mongo
-  return async.eachLimit(list, LIMIT, importOne, (importErr) => {
+  return async.mapLimit(list, LIMIT, importOne, (importErr, importResult) => {
     if (importErr) {
       return callback(importErr);
     }
 
-    console.log('------------------');
-    console.log('Finished importing data to Mongo');
-    console.log('------------------');
     mongoBackend.close(dbConn);
-    return callback();
+    return callback(null, importResult);
   });
 }
 
@@ -111,10 +116,6 @@ function main(opts, callback) {
   const dataDir = fsBackend.resolvePath(opts.dataDir);
   const collectionsToInclude = parsePotentialArray(opts.include);
   const collectionsToExclude = parsePotentialArray(opts.exclude);
-
-  console.log('------------------');
-  console.log('Starting import...');
-  console.log('------------------');
 
   // 1. get collections
   const allCollections = fsBackend.scanDirSync(dataDir);

--- a/lib/utils/resolveSelections.js
+++ b/lib/utils/resolveSelections.js
@@ -41,19 +41,21 @@ function resolveSelections(all, include, exclude) {
     }
   });
 
-  const aggForDisplay = _.map(aggregated, (col) => {
-    if (col.state === 'selected') {
-      return `+ ${col.name}`;
-    }
-    if (col.state === 'skipped') {
-      return `- ${col.name}`;
-    }
-    return `? ${col.name}`;
-  });
-
-  console.log(`${all.length} collections available:`);
-  console.log(aggForDisplay.join('\n'));
-  console.log('------------------');
+  // VERBOSE LOGGING
+  //
+  // const aggForDisplay = _.map(aggregated, (col) => {
+  //   if (col.state === 'selected') {
+  //     return `+ ${col.name}`;
+  //   }
+  //   if (col.state === 'skipped') {
+  //     return `- ${col.name}`;
+  //   }
+  //   return `? ${col.name}`;
+  // });
+  //
+  // console.log(`${all.length} collections available:`);
+  // console.log(aggForDisplay.join('\n'));
+  // console.log('------------------');
 
   return {
     full: aggregated,


### PR DESCRIPTION
* All modes are now passing the values through callback.
* Displaying results in StdOut is mostly handled by CLI layer now.
* Consistent arrays of `{collection, documents}` objects in callback data
* Consistent display of results in CLI
* `--verbose` mode added
* updated `example.js`