### PR TITLE
Fixed Import.JS CGI Path Logic

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -38,8 +38,11 @@ function importCollections(opts, callback) {
     if (!collection) {
       return cb('> Missing collection name in call to importOne method');
     }
+    //console.log(collection);
+    collection = /[^/]*$/.exec(collection)[0];
 
     return fsBackend.readFile(`${dataDir}/${collection}.json`, (readErr, readData) => {
+    //return fsBackend.readFile(`${collection}.json`, (readErr, readData) => {
       if (readErr) {
         return cb(readErr);
       }
@@ -119,7 +122,6 @@ function main(opts, callback) {
 
   // 1. get collections
   const allCollections = fsBackend.scanDirSync(dataDir);
-
   const resolved = resolveSelections(
     allCollections,
     collectionsToInclude,
@@ -137,7 +139,6 @@ function main(opts, callback) {
       connection: connDb,
       dataDir
     };
-
     return importCollections(newOpts, callback);
   });
 }


### PR DESCRIPTION
Currently the CGI path used to import DB collections contains an absolute reference to the root directory and collection file paths causing a invalid file path error on Windows machines. I have fixed this by using a regular expression on the collection variable (collection = /[^/]*$/.exec(collection)[0];).
